### PR TITLE
feat: add dark/light switch animations (testing CI/CD too!)

### DIFF
--- a/src/app/_app-theme.scss
+++ b/src/app/_app-theme.scss
@@ -1,3 +1,5 @@
+@use "animations";
+
 @mixin color($theme) {
   $background-palette: map-get($theme, background);
   $text-palette: map-get($theme, text);
@@ -5,6 +7,13 @@
   body {
     background: map-get($background-palette, main);
     color: map-get($text-palette, primary);
+  }
+}
+
+@mixin motion() {
+  body {
+    transition-property: color, background-color;
+    @include animations.transition(animations.$emphasized-style)
   }
 }
 

--- a/src/app/navigation-tabs/_navigation-tabs-theme.scss
+++ b/src/app/navigation-tabs/_navigation-tabs-theme.scss
@@ -1,3 +1,5 @@
+@use "animations";
+
 @mixin color($theme) {
   $background-palette: map-get($theme, background);
   $color-palette: map-get($theme, text);
@@ -21,6 +23,18 @@
     }
   }
 
+}
+
+@mixin motion() {
+  app-navigation-tabs {
+    transition-property: background-color, color;
+    @include animations.transition(animations.$emphasized-style);
+
+    ul > .selected {
+      transition-property: background-color, color;
+      @include animations.transition(animations.$emphasized-style);
+    }
+  }
 }
 
 @mixin theme($theme) {

--- a/src/app/profile/_profile-theme.scss
+++ b/src/app/profile/_profile-theme.scss
@@ -1,3 +1,5 @@
+@use "animations";
+
 @mixin color($theme) {
   $background-palette: map-get($theme, background);
   $image-opts: map-get($theme, image);
@@ -24,6 +26,23 @@
           border-right-color: transparent !important;
           border-bottom-color: map-get($background-palette, z2) !important;
         }
+      }
+    }
+  }
+}
+
+@mixin motion() {
+  app-profile {
+    .picture {
+      img {
+        transition: opacity animations.$standard-duration animations.$standard-easing;
+        transition-property: filter, background-color;
+        @include animations.transition(animations.$emphasized-style)
+      }
+
+      .comment {
+        transition-property: opacity, visibility;
+        @include animations.transition(animations.$standard-style)
       }
     }
   }

--- a/src/app/profile/profile.component.scss
+++ b/src/app/profile/profile.component.scss
@@ -21,10 +21,6 @@
       border-width: 1px;
     }
 
-    .main {
-      transition: opacity .75s;
-    }
-
     .huh {
       position: absolute;
       top: 0;
@@ -32,14 +28,11 @@
       right: 0;
       bottom: 0;
       opacity: 0;
-
-      transition: opacity .75s;
     }
 
     .comment {
       visibility: hidden;
       opacity: 0;
-      transition: opacity .75s, visibility .75s;
 
       position: absolute;
 

--- a/src/app/window/_window-theme.scss
+++ b/src/app/window/_window-theme.scss
@@ -1,3 +1,5 @@
+@use "animations";
+
 @mixin color($theme) {
   $background-palette: map-get($theme, background);
 
@@ -7,6 +9,13 @@
     > * {
       border-color: map-get($theme, hairline);
     }
+  }
+}
+
+@mixin motion() {
+  app-window {
+    transition-property: background-color;
+    @include animations.transition(animations.$emphasized-style)
   }
 }
 

--- a/src/sass/_animations.scss
+++ b/src/sass/_animations.scss
@@ -1,0 +1,37 @@
+// https://m3.material.io/styles/motion
+$standard-style: standard;
+$emphasized-style: emphasized;
+$standard-easing: cubic-bezier(0.2, 0.0, 0, 1.0);
+
+$short-durations: (
+  1: 50ms,
+  2: 100ms,
+  3: 150ms,
+  4: 200ms,
+);
+$short-duration: map-get($short-durations, 2);
+$medium-durations: (
+  1: 250ms,
+  2: 300ms,
+  3: 350ms,
+  4: 400ms,
+);
+$medium-duration: map-get($medium-durations, 2);
+$standard-duration: $medium-duration;
+$long-durations: (
+  1: 450ms,
+  2: 500ms,
+  3: 550ms,
+  4: 600ms,
+);
+$long-duration: map-get($long-durations, 2);
+$emphasized-duration: $long-duration;
+
+@mixin transition($style: $standard-style) {
+  $duration: $standard-duration;
+  @if ($style: $emphasized-style) {
+    $duration: $emphasized-duration;
+  }
+  transition-duration: $duration;
+  transition-timing-function: $standard-easing;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -57,3 +57,9 @@ code, pre {
 }
 
 @include theming.display-hide-classes();
+
+// Add animations
+@include root-theme.motion;
+@include window-theme.motion;
+@include profile-theme.motion;
+@include navigation-tabs-theme.motion;

--- a/src/test/color-scheme.spec.ts
+++ b/src/test/color-scheme.spec.ts
@@ -2,12 +2,15 @@ import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { AppModule } from '../app/app.module';
 import { ColorSchemeService, Scheme } from '../app/toolbar/color-scheme.service';
+import { sleep } from './helpers/sleep';
 
 describe('App color scheme', () => {
   let bodyElement: HTMLElement;
   let colorSchemeService: ColorSchemeService;
   const LIGHT_MIN_LUMINANCE = 0.75;
   const DARK_MAX_LUMINANCE = 0.25;
+  // TODO: if we respect no motion, we can go back to instant tests
+  const ANIMATION_MILLIS = 700;
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
@@ -20,30 +23,27 @@ describe('App color scheme', () => {
   });
 
   describe('when light color scheme is set', () => {
-    beforeEach(() => {
+    it('body should have a light background color (high luminance), whilst text color should be a dark one (low luminance)', async () => {
       colorSchemeService.setManual(Scheme.Light);
-    })
-    it('body should have a light background color (high luminance)', () => {
+      await sleep(ANIMATION_MILLIS);
+
       const bodyBackgroundColor = getRgbFromCssRgbColor(getComputedStyle(bodyElement).backgroundColor);
       const bodyBackgroundColorLuminance = getRelativeLuminance(bodyBackgroundColor);
       expect(bodyBackgroundColorLuminance).toBeGreaterThan(LIGHT_MIN_LUMINANCE);
-    })
-    it('body text should have a dark color (low luminance)', () => {
       const bodyTextColor = getRgbFromCssRgbColor(getComputedStyle(bodyElement).color);
       const bodyTextColorLuminance = getRelativeLuminance(bodyTextColor);
       expect(bodyTextColorLuminance).toBeLessThan(DARK_MAX_LUMINANCE);
     })
   })
   describe('when dark color scheme is set', () => {
-    beforeEach(() => {
+    it('body should have a dark background color (low luminance), whilst text color should be a light one (high luminance)', async () => {
       colorSchemeService.setManual(Scheme.Dark);
-    })
-    it('body should have a dark background color (low luminance)', () => {
+      await sleep(ANIMATION_MILLIS);
+
       const bodyBackgroundColor = getRgbFromCssRgbColor(getComputedStyle(bodyElement).backgroundColor);
       const bodyBackgroundColorLuminance = getRelativeLuminance(bodyBackgroundColor);
       expect(bodyBackgroundColorLuminance).toBeLessThan(DARK_MAX_LUMINANCE);
-    })
-    it('body text should have a light color (high luminance)', () => {
+
       const bodyTextColor = getRgbFromCssRgbColor(getComputedStyle(bodyElement).color);
       const bodyTextColorLuminance = getRelativeLuminance(bodyTextColor);
       expect(bodyTextColorLuminance).toBeGreaterThan(LIGHT_MIN_LUMINANCE);

--- a/src/test/helpers/sleep.ts
+++ b/src/test/helpers/sleep.ts
@@ -1,0 +1,5 @@
+export async function sleep(millis: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, millis)
+  });
+}


### PR DESCRIPTION
Adds an animation when switching color schemes (dark/light). Background color (those that fill most of screen) and text colours will be transitioned with an animation based on Material's 3 motion guide.

This is a test PR to:
1. Ensure pull request GitHub actions workflow works properly
   - Commits with fixes to issues found: 87f9f81f271c86a99cf68328784a388969018dc4 a403c0a5b0a5a58ed1f841df4b59dbb0f4525e1c
3. Add ~Netlify~ previews so we can see the effects of this PR in a separately deployed site
   - Eventually went with Cloudflare Pages. Less limitations!