### PR TITLE
ci: play with PR workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,5 +7,5 @@ jobs:
   playground:
     runs-on: ubuntu-latest
     steps:
-      - name: Test GitHub event contents
-        run: echo ${{ github.event }}
+      - name: Test GitHub contents
+        run: echo ${{ toJson(github) }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,34 +4,8 @@ on:
   pull_request:
 
 jobs:
-  build:
-    name: Build
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      artifact-name: build
-  test:
-    name: Test
-    uses: ./.github/workflows/reusable-test.yml
-  lint:
-    name: Lint
-    uses: ./.github/workflows/reusable-lint.yml
-  performance:
-    name: Performance
-    needs: build
-    uses: ./.github/workflows/reusable-performance.yml
-    with:
-      build-artifact-name: build
-    secrets:
-      LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-  deploy-preview:
-    name: Deploy preview
-    needs: [build, lint, test, performance]
-    uses: ./.github/workflows/reusable-deploy-cloudflare-pages.yml
-    with:
-      build-artifact-name: build
-    secrets:
-      cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    permissions:
-      contents: read
-      deployments: write
+  playground:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test GitHub event contents
+        run: echo ${{ github.event }}


### PR DESCRIPTION
Just testing :P I want to see if I can reduce the number of Cloudflare Pages deploys by only enabling preview ones in case the dev wants them. Same could apply for main builds (state in a commit that you don't want to deploy that for instance).

Ideas:
 - Something in the commit message
   - Maybe pollutes the message?
 - Something in PR body
 - Something as a PR comment (kinda like `/dependabot` commands)