### PR TITLE
ci(cloudflare): skip deploy preview if PR closed on reusable workflow step

### DIFF
--- a/.github/workflows/reusable-deploy-cloudflare-pages.yml
+++ b/.github/workflows/reusable-deploy-cloudflare-pages.yml
@@ -31,6 +31,7 @@ jobs:
           name: ${{ inputs.build-artifact-name }}
       - name: Publish
         uses: cloudflare/pages-action@1
+        if: "! (github.event_name == 'pull_request' && github.event.pull_request.state == 'closed')"
         with:
           accountId: ${{ secrets.cloudflare-account-id }}
           apiToken: ${{ secrets.cloudflare-api-token }}

--- a/src/index.html
+++ b/src/index.html
@@ -29,21 +29,22 @@
   <noscript>
     <!--suppress CssUnusedSymbol (used in inner components, but WebStorm doesn't go so far :P) -->
     <style>
-        /**
-         * So we can show or hide features if JS is not enabled. If we did this with JS, we may add some flickering.
-         * For instance, some items could be shown to later be hidden with JS is enabled and using ".showIfNoScript".
-         * Specifically, the navigation tabs and the active tab items. Or displaying the toolbar and navigation tabs if
-         * JS is enabled.
-         **/
-        .showIfNoScript {
-            display: block !important;
-        }
+      /**
+       * So we can show or hide features if JS is not enabled. If we did this with JS, we may add some flickering.
+       * For instance, some items could be shown to later be hidden with JS is enabled and using ".showIfNoScript".
+       * Specifically, the navigation tabs and the active tab items. Or displaying the toolbar and navigation tabs if
+       * JS is enabled.
+       **/
+      .showIfNoScript {
+        display: block !important;
+      }
 
-        .hideIfNoScript {
-            display: none !important;
-        }
+      .hideIfNoScript {
+        display: none !important;
+      }
     </style>
   </noscript>
+  <!-- Test to actually trigger a Cloudflare Pages deploy -->
 </head>
 <body>
 <app-root></app-root>


### PR DESCRIPTION
Another try of fixing issue #8 based on PR #5 but doing the condition inside the workflow step. 

Adding some changes to HTML otherwise seems that the job skips creating the deployment (which is when it fails). For instance: https://github.com/davidlj95/website-v2/actions/runs/6053285737