### PR TITLE
feat: release info in other branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,30 @@ yarn run generate-release-file
 It will generate a `release.json` file in the root of the repository containing all info about releases that
 [Semantic Release][semantic-release] provides.
 
-> ⚠️ The API only outputs information when a new release has to be generated. As a workaround, a fake
-> patch release is generated in case no release was needed so we get access to all that info. To distinguish a real
-> run from a faked run, a `fake` property exists in that JSON.
-> The only faked properties are about next release (`nextRelease` and `releases` at the moment of writing this). Info
+> ⚠️ **Next release can be fake**
+>
+> The API only outputs information when a new release has to be generated. As a
+> workaround, a fake
+> patch release is generated in case no release was needed to get access to all that info.
+>
+> **To distinguish a real run from a faked run, a `fake` property exists in that JSON** with value set to `true`. The
+> only faked properties are about next release (`nextRelease` and `releases` at the moment of writing this). Info
 > about last release
-> is correct even when faking the release to generate the output (`lastRelease` at the moment of writing this)
+> remains correct even when faking the release to generate the output (`lastRelease` at the moment of writing this)
+
+> ⚠️ **Next release can be a preview**
+>
+> If running the script from a branch that's not configured to trigger releases, the default API behaviour is to
+> output no data. As a workaround, we simulate being on the `main` branch and see what would happen in that scenario
+> when including commits from the current branch.
+>
+> **To distinguish a real run from a faked run, a `preview` property exists in that JSON** with value set to `true`.
+> This is because it's a simulation of this branch being merged into main branch. But you could want to merge that
+> against another (the script could be smarter and simulate that too, but not yet :P).
+
+> ⚠️ **Next release can be fake and preview**
+> If both of previous situations happen at same time (commits of branch are not enough to trigger a release and
+> branch is not one configured for releases)
 
 ## Git hooks
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "conventional-changelog-conventionalcommits": "^7.0.1",
     "eslint": "^8.47.0",
     "eslint-formatter-multiple": "^2.0.0",
+    "execa": "^8.0.1",
     "glob": "^10.3.3",
     "husky": "^8.0.3",
     "jasmine-core": "~4.6.0",

--- a/src/app/release-info/release-info.component.ts
+++ b/src/app/release-info/release-info.component.ts
@@ -13,11 +13,13 @@ export class ReleaseInfoComponent {
 
   protected get releaseAsJsonString() {
     const nextRelease = this.release.nextRelease;
-    const nextReleaseWithoutNotes = {
+    const summary = {
       ...nextRelease,
       notes: undefined,
+      preview: this.release.preview,
+      fake: this.release.fake,
     }
-    return JSON.stringify(nextReleaseWithoutNotes, null, 2)
+    return JSON.stringify(summary, null, 2)
   }
 }
 

--- a/src/app/release-info/semantic-release.d.ts
+++ b/src/app/release-info/semantic-release.d.ts
@@ -1,6 +1,6 @@
 import { Commit, LastRelease, NextRelease, Release, Result } from 'semantic-release';
 
-export type ReleaseInfo = PatchedResultObject | FakeResultObject;
+export type ReleaseInfo = PatchedResultObject & { fake?: true, preview?: true }
 
 type ResultObject = Exclude<Result, false>
 // Turns out the generated JSON contains different things from what was promised
@@ -21,4 +21,3 @@ type PatchedCommitAuthor = Omit<Commit['author'], 'short'> & { date: string }
 type PatchedCommitCommitter = Omit<Commit['committer'], 'short'> & { date: string }
 type PatchedNextRelease = Omit<NextRelease, 'channel'> & { channel: NextRelease['channel'] | null }
 type PatchedRelease = Omit<Release, 'pluginName'> & { pluginName?: Release['pluginName'] }
-type FakeResultObject = PatchedResultObject & { fake: true }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2697,6 +2697,7 @@ __metadata:
     conventional-changelog-conventionalcommits: ^7.0.1
     eslint: ^8.47.0
     eslint-formatter-multiple: ^2.0.0
+    execa: ^8.0.1
     express: ^4.15.2
     gardevoir: ^1.0.0
     glob: ^10.3.3
@@ -8576,7 +8577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^8.0.0":
+"execa@npm:^8.0.0, execa@npm:^8.0.1":
   version: 8.0.1
   resolution: "execa@npm:8.0.1"
   dependencies:


### PR DESCRIPTION
Allow generating release information file `release.json` in other branches apart from `main`. So we can preview what would happen when running locally / in a PR's CI/CD in a different branch.

